### PR TITLE
Fixed compile issue with typecasting using reinterpret_cast

### DIFF
--- a/include/cpp3ds/Graphics/Transform.hpp
+++ b/include/cpp3ds/Graphics/Transform.hpp
@@ -85,8 +85,11 @@ public :
     /// \return Pointer to a 4x4 matrix
     ///
     ////////////////////////////////////////////////////////////
+    #ifdef EMULATION
     const float* getMatrix() const;
-
+    #else
+    const C3D_Mtx* getMatrix() const;
+    #endif
     ////////////////////////////////////////////////////////////
     /// \brief Return the inverse of the transform
     ///

--- a/src/cpp3ds/Graphics/Shader.cpp
+++ b/src/cpp3ds/Graphics/Shader.cpp
@@ -235,7 +235,7 @@ void Shader::setParameter(const std::string& name, const cpp3ds::Transform& tran
         int location = getParamLocation(name);
         if (location != -1)
         {
-            C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, location, reinterpret_cast<const C3D_Mtx*>(transform.getMatrix()));
+            C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, location, (C3D_Mtx*)transform.getMatrix());
         }
     }
 }

--- a/src/cpp3ds/Graphics/Transform.cpp
+++ b/src/cpp3ds/Graphics/Transform.cpp
@@ -76,11 +76,17 @@ void Transform::apply3dsFix()
 
 
 ////////////////////////////////////////////////////////////
+#ifdef EMULATION
 const float* Transform::getMatrix() const
 {
-    return m_matrix.m;
+    return m_matrix;
 }
-
+#else
+const C3D_Mtx* Transform::getMatrix() const
+{
+  return &m_matrix;
+}
+#endif
 
 ////////////////////////////////////////////////////////////
 Transform Transform::getInverse() const


### PR DESCRIPTION
it's a dirty fix, I also added some new function defs if we aren't emulating so that getMatrix() returns a C3DMtx instead of a float. Seems like more work is needed here. I never tested it at all, the main thing here was to get it to compile :)
